### PR TITLE
fix(workers/dprint.cjs): TypeError: r.buffer is not a function

### DIFF
--- a/workers/dprint.cjs
+++ b/workers/dprint.cjs
@@ -15,7 +15,7 @@ async function loadBuffer(data) {
       return Buffer.from(base64, 'base64')
     }
     else if (data.match(/^[\w-]+:\/\//)) {
-      return fetch(data).then(r => r.buffer())
+      return fetch(data).then(r => r.arrayBuffer())
     }
     else {
       return fs.readFile(data)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fix dprint worker failed to fetch wasm module from url.

```text
TypeError: r.buffer is not a function
    at /node_modules/.pnpm/eslint-plugin-format@0.1.2_eslint@9.15.0_jiti@2.4.0_/node_modules/eslint-plugin-format/workers/dprint.cjs:18:38
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /node_modules/.pnpm/eslint-plugin-format@0.1.2_eslint@9.15.0_jiti@2.4.0_/node_modules/eslint-plugin-format/workers/dprint.cjs:45:21
```

### Linked Issues

None.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
