### PR TITLE
feat: add support for multiple dprint plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,36 @@ export default [
       'format/dprint': ['error', { language: 'toml', languageOptions: { indentWidth: 2 } }],
     },
   },
+
+  // use dprint to format HTML and CSS in style tags
+  {
+    files: ['**/*.html'],
+    languageOptions: {
+      parser: format.parserPlain,
+    },
+    plugins: {
+      format,
+    },
+    rules: {
+      'format/dprint': ['error', {
+        plugins: [
+          {
+            plugin: 'node_modules/dprint-plugin-malva/plugin.wasm',
+            options: {},
+          },
+          {
+            plugin: 'node_modules/dprint-plugin-markup/plugin.wasm',
+            options: {
+              scriptIndent: true,
+              styleIndent: true,
+            },
+          },
+        ],
+        useTabs: false,
+        indentWidth: 2,
+      }],
+    },
+  },
 ]
 ```
 
@@ -74,9 +104,14 @@ Use dprint to format files.
 
 #### Options
 
+Either:
 - `language` (required) - the language to format, or can be a filepath or URL to the WASM binary. [Supported languages](https://dprint.dev/plugins/)
 - `languageOptions` - the options for the language
 - The rest options are passed as dprint's general options
+
+Or:
+- `plugins` (required) - Array of plugins, defined as an object containing `plugin` (same as `language` above) and `options`, which is the same as `languageOptions` above.
+- The rest of the options are passed as dprint's general options
 
 ## Sponsors
 

--- a/dts/rule-options.d.ts
+++ b/dts/rule-options.d.ts
@@ -7,8 +7,6 @@ export interface RuleOptions {
 
 export { PrettierOptions }
 
-export interface DprintOptions {
-  language: string
-  languageOptions?: Record<string, unknown>
-  [x: string]: unknown
-}
+export type DprintOptions
+  = | { language: string, languageOptions?: Record<string, unknown>, [x: string]: unknown }
+    | { plugins: Array<{ plugin: string, options?: Record<string, unknown> }>, [x: string]: unknown }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint": "^8.40.0 || ^9.0.0"
   },
   "dependencies": {
-    "@dprint/formatter": "^0.4.1",
+    "@dprint/formatter": "^0.5.1",
     "@dprint/markdown": "^0.20.0",
     "@dprint/toml": "^0.7.0",
     "eslint-formatting-reporter": "^0.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@dprint/formatter':
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: ^0.5.1
+        version: 0.5.1
       '@dprint/markdown':
         specifier: ^0.20.0
         version: 0.20.0
@@ -185,8 +185,8 @@ packages:
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
-  '@dprint/formatter@0.4.1':
-    resolution: {integrity: sha512-IB/GXdlMOvi0UhQQ9mcY15Fxcrc2JPadmo6tqefCNV0bptFq7YBpggzpqYXldBXDa04CbKJ+rDwO2eNRPE2+/g==}
+  '@dprint/formatter@0.5.1':
+    resolution: {integrity: sha512-cdZUrm0iv/FnnY3CKE2dEcVhNEzrC551aE2h2mTFwQCRBrqyARLDnb7D+3PlXTUVp3s34ftlnGOVCmhLT9DeKA==}
 
   '@dprint/markdown@0.20.0':
     resolution: {integrity: sha512-qvynFdQZwul4Y+hoMP02QerEhM5VItb4cO8/qpQrSuQuYvDU+bIseiheVAetSpWlNPBU1JK8bQKloiCSp9lXnA==}
@@ -855,56 +855,67 @@ packages:
     resolution: {integrity: sha512-WEWAGFNFFpvSWAIT3MYvxTkYHv/cJl9yWKpjhheg7ONfB0hetZt/uwBnM3GZqSHrk5bXCDYTFXg3jQyk/j7eXQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.51.0':
     resolution: {integrity: sha512-9bxtxj8QoAp++LOq5PGDGkEEOpCDk9rOEHUcXadnijedDH8IXrBt6PnBa4Y6NblvGWdoxvXZYghZLaliTCmAng==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.51.0':
     resolution: {integrity: sha512-DdqA+fARqIsfqDYkKo2nrWMp0kvu/wPJ2G8lZ4DjYhn+8QhrjVuzmsh7tTkhULwjvHTN59nWVzAixmOi6rqjNA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.51.0':
     resolution: {integrity: sha512-2XVRNzcUJE1UJua8P4a1GXS5jafFWE+pQ6zhUbZzptOu/70p1F6+0FTi6aGPd6jNtnJqGMjtBCXancC2dhYlWw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.51.0':
     resolution: {integrity: sha512-R8QhY0kLIPCAVXWi2yftDSpn7Jtejey/WhMoBESSfwGec5SKdFVupjxFlKoQ7clVRuaDpiQf7wNx3EBZf4Ey6g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.51.0':
     resolution: {integrity: sha512-I498RPfxx9cMv1KTHQ9tg2Ku1utuQm+T5B+Xro+WNu3FzAFSKp4awKfgMoZwjoPgNbaFGINaOM25cQW6WuBhiQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.51.0':
     resolution: {integrity: sha512-o8COudsb8lvtdm9ixg9aKjfX5aeoc2x9KGE7WjtrmQFquoCRZ9jtzGlonujE4WhvXFepTraWzT4RcwyDDeHXjA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.51.0':
     resolution: {integrity: sha512-0shJPgSXMdYzOQzpM5BJN2euXY1f8uV8mS6AnrbMcH2KrkNsbpMxWB1wp8UEdiJ1NtyBkCk3U/HfX5mEONBq6w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.51.0':
     resolution: {integrity: sha512-L7pV+ny7865jamSCQwyozBYjFRUKaTsPqDz7ClOtJCDu4paf2uAa0mrcHwSt4XxZP2ogFZS9uuitH3NXdeBEJA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.51.0':
     resolution: {integrity: sha512-4YHhP+Rv3T3+H3TPbUvWOw5tuSwhrVhkHHZhk4hC9VXeAOKR26/IsUAT4FsB4mT+kfIdxxb1BezQDEg/voPO8A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.51.0':
     resolution: {integrity: sha512-P7U7U03+E5w7WgJtvSseNLOX1UhknVPmEaqgUENFWfNxNBa1OhExT6qYGmyF8gepcxWSaSfJsAV5UwhWrYefdQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.51.0':
     resolution: {integrity: sha512-FuD8g3u9W6RPwdO1R45hZFORwa1g9YXEMesAKP/sOi7mDqxjbni8S3zAXJiDcRfGfGBqpRYVuH54Gu3FTuSoEw==}
@@ -3054,7 +3065,7 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@dprint/formatter@0.4.1': {}
+  '@dprint/formatter@0.5.1': {}
 
   '@dprint/markdown@0.20.0': {}
 

--- a/src/rules/dprint.ts
+++ b/src/rules/dprint.ts
@@ -26,6 +26,9 @@ export default {
           languageOptions: {
             type: 'object',
           },
+          plugins: {
+            type: 'array',
+          },
         },
         additionalProperties: true,
       },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

Some dprint plugins can use other dprint plugins to format nested code. For example, you can use [markup_fmt](https://github.com/g-plane/markup_fmt) with [Malva](https://github.com/g-plane/malva) to format CSS inside of HTML, Vue, Svelte, Astro, etc., `@dprint/formatter` recently added an API for handling this, see https://github.com/dprint/js-formatter/tree/7f90524?tab=readme-ov-file#use.

Example config for this:

```ts
{
  files: ["**/*.svelte"],
  languageOptions: {
    parser: format.parserPlain,
  },
  plugins: {
    format,
  },
  rules: {
    "format/dprint": ["error", {
      plugins: [
        {
          plugin: "node_modules/dprint-plugin-malva/plugin.wasm",
          options: {},
        },
        {
          plugin: "node_modules/dprint-plugin-markup/plugin.wasm",
          options: {
            scriptIndent: true,
            styleIndent: true,
          },
        },
      ],
      useTabs: false,
      indentWidth: 2,
    }],
  },
}
```

### Linked Issues

### Additional context

Not sure about the API design, also we don't cache the context for multi-formatter setups.
