### PR TITLE
feat: cache the dprint context

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@dprint/toml": "^0.7.0",
     "eslint-formatting-reporter": "^0.0.0",
     "eslint-parser-plain": "^0.1.1",
+    "ohash": "^2.0.11",
     "prettier": "^3.7.4",
     "synckit": "^0.11.11"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       eslint-parser-plain:
         specifier: ^0.1.1
         version: 0.1.1
+      ohash:
+        specifier: ^2.0.11
+        version: 2.0.11
       prettier:
         specifier: ^3.7.4
         version: 3.7.4


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

Currently, when using multiple dprint plugins, we do not cache the context.
This PR caches the context using the strategy described in https://github.com/antfu/eslint-plugin-format/pull/13#issuecomment-3741955170.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
